### PR TITLE
Disable Netdata cloud link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The setup is highly opinionated.
 * We differ between two types of streaming nodes: `silence` will deactivate all alarms but still collect data. `default` will activate all alarms.
 * Historic data will be stored within Netdatas own database mechanism.
 * We deactivated several TCP/UDP-related metrics
+* Links to Netdata cloud are disabled
 
 This setup is reflected within the variables:
 

--- a/files/cloud.d/cloud.conf
+++ b/files/cloud.d/cloud.conf
@@ -1,0 +1,2 @@
+[global]
+enabled = no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,11 +38,29 @@
   notify:
     - "Restart Netdata"
 
+- name: Create cloud configuration directory
+  file:
+    path: /var/lib/netdata/cloud.d
+    state: directory
+    owner: "netdata"
+    group: "netdata"
+    mode: 0600
+
+- name: Copy cloud.conf
+  copy:
+    src: cloud.d/cloud.conf
+    dest: /var/lib/netdata/cloud.d/cloud.conf
+    owner: "netdata"
+    group: "netdata"
+    mode: 0600
+  notify:
+    - "Restart Netdata"
+
 - name: Make sure systemd folder for unit files exists
   file:
     path: /etc/systemd/system/netdata.service.d
     state: directory
-    mode: '0755'
+    mode: "0755"
     owner: "root"
     group: "root"
 


### PR DESCRIPTION
Since we don't use Netdata cloud, this PR will disable the feature from the service. This results in the links in the dashboard being hidden and no connection being made by the service to the cloud.