### PR TITLE
Remove `cloud.conf` from role

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: 3.x
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule[docker] docker
+        run: pip3 install ansible molecule molecule-plugins[docker] docker
 
       - name: Run Molecule tests.
         run: molecule test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,11 @@ jobs:
     strategy:
       matrix:
         distro:
-          - ubuntu1804
           - ubuntu2004
           - ubuntu2204
-          - debian9
           - debian10
           - debian11
+          - debian12
 
     steps:
       - name: Check out the codebase.

--- a/files/cloud.d/cloud.conf
+++ b/files/cloud.d/cloud.conf
@@ -1,2 +1,0 @@
-[global]
-enabled = no

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -42,7 +42,8 @@ galaxy_info:
         - hirsute
         - impish
 
-  galaxy_tags: []
+  galaxy_tags:
+    []
     # List tags for your role here, one per line. A tag is a keyword that describes
     # and categorizes the role. Users find roles by searching for tags. Be sure to
     # remove the '[]' above, if you add tags to this list.
@@ -51,7 +52,8 @@ galaxy_info:
     #       Maximum 20 tags per role.
 
 dependencies:
-  - {role: simplificator.netdata_installation}
-  - {role: simplificator.caddy}
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.
+  - role: simplificator.netdata_installation
+    netdata_installation_disable_cloud: yes
+    netdata_installation_monitor_docker: yes
+
+  - role: simplificator.caddy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,24 +38,6 @@
   notify:
     - "Restart Netdata"
 
-- name: Create cloud configuration directory
-  file:
-    path: /var/lib/netdata/cloud.d
-    state: directory
-    owner: "netdata"
-    group: "netdata"
-    mode: 0770
-
-- name: Copy cloud.conf
-  copy:
-    src: cloud.d/cloud.conf
-    dest: /var/lib/netdata/cloud.d/cloud.conf
-    owner: "netdata"
-    group: "netdata"
-    mode: 0770
-  notify:
-    - "Restart Netdata"
-
 - name: Make sure systemd folder for unit files exists
   file:
     path: /etc/systemd/system/netdata.service.d


### PR DESCRIPTION
This has been moved to the installation role, see https://github.com/simplificator/ansible-role-netdata_installation/pull/29.

As the pipeline failed for a while, I also included the necessary updates to it to have green PR to merge :)