### PR TITLE
Add variable for hosts in disk health template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           python-version: 3.x
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-plugins[docker] docker
+        run: pip3 install "ansible==8.2.0" "ansible-core==2.15.2" "molecule<6" molecule-plugins[docker] docker
 
       - name: Run Molecule tests.
         run: molecule test

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,4 @@ netdata_collector_db_tiering:
 netdata_hostname: "auto-detected"
 netdata_collector_domain: "{{ netdata_collector_registry_domain }}"
 netdata_collector_page_cache_size: 4096
+netdata_collector_custom_hosts_for_disk_conf: "*"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,10 +14,15 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
-  env:
-    ANSIBLE_VERBOSITY: 3
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+scenario:
+  test_sequence:
+    - dependency
+    - destroy
+    - create
+    - converge
+    - verify
 
 verifier:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,6 +14,8 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  env:
+    ANSIBLE_VERBOSITY: 3
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,8 +29,8 @@
     - "Restart Netdata"
 
 - name: Copy disks.conf
-  copy:
-    src: health.d/disks.conf
+  template:
+    src: "disks.conf.j2"
     dest: /etc/netdata/health.d/disks.conf
     owner: "netdata"
     group: "netdata"

--- a/templates/disks.conf.j2
+++ b/templates/disks.conf.j2
@@ -3,7 +3,7 @@
 template: 60min_disk_utilization
       on: disk.util
       os: linux freebsd
-   hosts: *
+   hosts: {{ netdata_collector_custom_hosts_for_disk_conf }}
 families: *
   lookup: average -60m unaligned
    units: %


### PR DESCRIPTION
This PR introduces  a new variable `netdata_collector_custom_hosts_for_disk_conf`. If not provided, deafult value is set to `*`.
With this change it will be possible to configure which hosts should be excluded from `60min_disk_utilization` metric.

